### PR TITLE
Multiple fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+skip_tags: true
+cache:
+  - C:\strawberry\perl\site
+install:
+  - cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm Test::TCP
+  - cpanm --installdeps .
+build_script:
+  - cpanm -v --test-only .

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,11 @@ blib/
 pm_to_blib
 /Proc-Guard-*
 /.build
+/_build
 /_build_params
 /Build
 /Build.bat
 !Build/
 !META.json
 !LICENSE
+/MYMETA.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 perl:
   - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: perl
-before_script:
-  - "git config --global user.email 'you@example.com'"
-  - "git config --global user.name 'Your Name'"
-install:
-  - "cpanm --notest Module::Build ExtUtils::ParseXS"
-  - "cpanm --with-recommends --with-suggests --installdeps --notest ."
 perl:
   - "5.14"
   - "5.16"
   - "5.18"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"

--- a/Build.PL
+++ b/Build.PL
@@ -4,62 +4,9 @@
 # =========================================================================
 
 use 5.008_001;
-
 use strict;
-use warnings;
-use utf8;
 
-use Module::Build;
-use File::Basename;
-use File::Spec;
+use Module::Build::Tiny 0.035;
 
-my %args = (
-    license              => 'perl',
-    dynamic_config       => 0,
-
-    configure_requires => {
-        'Module::Build' => 0.38,
-    },
-
-    name            => 'Proc-Guard',
-    module_name     => 'Proc::Guard',
-    allow_pureperl => 0,
-
-    script_files => [glob('script/*'), glob('bin/*')],
-    c_source     => [qw()],
-    PL_files => {},
-
-    test_files           => ((-d '.git' || $ENV{RELEASE_TESTING}) && -d 'xt') ? 't/ xt/' : 't/',
-    recursive_test_files => 1,
-
-
-);
-if (-d 'share') {
-    $args{share_dir} = 'share';
-}
-
-my $builder = Module::Build->subclass(
-    class => 'MyBuilder',
-    code => q{
-        sub ACTION_distmeta {
-            die "Do not run distmeta. Install Minilla and `minil install` instead.\n";
-        }
-        sub ACTION_installdeps {
-            die "Do not run installdeps. Run `cpanm --installdeps .` instead.\n";
-        }
-    }
-)->new(%args);
-$builder->create_build_script();
-
-use File::Copy;
-
-print "cp META.json MYMETA.json\n";
-copy("META.json","MYMETA.json") or die "Copy failed(META.json): $!";
-
-if (-f 'META.yml') {
-    print "cp META.yml MYMETA.yml\n";
-    copy("META.yml","MYMETA.yml") or die "Copy failed(META.yml): $!";
-} else {
-    print "There is no META.yml... You may install this module from the repository...\n";
-}
+Build_PL();
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl module Proc::Guard
 
 {{$NEXT}}
 
+0.07_01 2018-06-29T20:31:04Z
+
+    - Fix hanging on Windows (nponeccop)
+    - Use SIGTERM followed by SIGKILL on Unix
+
 0.07 2015-03-25T22:40:00Z
 
     - Fixed infinite loop

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno <tokuhirom AAJKLFJEF GMAIL COM>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.2.0, CPAN::Meta::Converter version 2.141520",
+   "generated_by" : "Minilla/v3.1.1, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -35,7 +35,7 @@
       },
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.38"
+            "Module::Build::Tiny" : "0.035"
          }
       },
       "develop" : {
@@ -59,19 +59,22 @@
    "release_status" : "unstable",
    "resources" : {
       "bugtracker" : {
-         "web" : "https://github.com/tokuhirom/Proc-Guard/issues"
+         "web" : "https://github.com/nponeccop/Proc-Guard/issues"
       },
-      "homepage" : "https://github.com/tokuhirom/Proc-Guard",
+      "homepage" : "https://github.com/nponeccop/Proc-Guard",
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/tokuhirom/Proc-Guard.git",
-         "web" : "https://github.com/tokuhirom/Proc-Guard"
+         "url" : "git://github.com/nponeccop/Proc-Guard.git",
+         "web" : "https://github.com/nponeccop/Proc-Guard"
       }
    },
-   "version" : "0.07",
+   "version" : "0.07_01",
    "x_contributors" : [
-      "Neil Bowers <neil@bowers.com>",
+      "Andrii Melnykov <andy.melnikov@gmail.com>",
       "David Golden <dagolden@cpan.org>",
+      "Neil Bowers <neil@bowers.com>",
       "Tokuhiro Matsuno <tokuhirom@gmail.com>"
-   ]
+   ],
+   "x_serialization_backend" : "JSON::PP version 2.27400_02",
+   "x_static_install" : 1
 }

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This is useful for testing code working with server process.
 
 # AUTHOR
 
-Tokuhiro Matsuno <tokuhirom AAJKLFJEF GMAIL COM>
+Tokuhiro Matsuno &lt;tokuhirom AAJKLFJEF GMAIL COM>
 
 # LICENSE
 

--- a/lib/Proc/Guard.pm
+++ b/lib/Proc/Guard.pm
@@ -2,7 +2,7 @@ package Proc::Guard;
 use strict;
 use warnings;
 use 5.00800;
-our $VERSION = '0.07';
+our $VERSION = '0.07_01';
 use Carp ();
 
 our $EXIT_STATUS;


### PR DESCRIPTION
There are following changes:
- Add .appveyor.yml for Windows CI
- Fix tests hanging on Windows and use SIGTERM/SIGKILL on Unix - closes #5 and #3 
- Fix .travis.yml
- Regenerate the files using a newer Minil to fix problems with @INC in newer perls

They were also tested by CPAN Testers: http://matrix.cpantesters.org/?dist=Proc%3A%3AGuard#

So I suggest applying the fixes, regenerating everything using the current Minil and uploading a new version to CPAN.