### PR TITLE
suppress redefined warnings

### DIFF
--- a/lib/Proc/Guard.pm
+++ b/lib/Proc/Guard.pm
@@ -21,7 +21,7 @@ sub proc_guard {
 }
 
 # OOish interface
-use POSIX;
+use POSIX qw/:signal_h/;
 use Errno qw/EINTR ECHILD/;
 use Class::Accessor::Lite 0.05 (
 	rw => ['pid'],


### PR DESCRIPTION
```
Constant subroutine Proc::Guard::EINTR redefined at $HOME/.anyenv/envs/plenv/versions/5.30/lib/perl5/5.30.0/Exporter.pm line 66.
 at $HOME/.anyenv/envs/plenv/versions/5.30/lib/perl5/site_perl/5.30.0/Proc/Guard.pm line 25.
Constant subroutine Proc::Guard::ECHILD redefined at $HOME/.anyenv/envs/plenv/versions/5.30/lib/perl5/5.30.0/Exporter.pm line 66.
 at $HOME/.anyenv/envs/plenv/versions/5.30/lib/perl5/site_perl/5.30.0/Proc/Guard.pm line 25.
```